### PR TITLE
Update tanslator.dart and support dynamic templateFilename.

### DIFF
--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -8,12 +8,15 @@ import 'package:yaml/yaml.dart';
 const String _helpFlag = 'help';
 
 /// Yaml file used to configure Translator.
-const String configFile = 'l10n.yaml';
+String configFile = 'l10n.yaml';
 const String _translatorKey = 'translator';
 const String _defaultKeyFile = 'translator_key';
 
 /// Parses arguments from command line, providing help or running [Translator].
-Future<void> runWithArguments(List<String> arguments) async {
+Future<void> runWithArguments(List<String> arguments, {
+  String? yaml,
+}) async {
+  if (yaml != null) configFile = yaml;
   final ArgParser parser = ArgParser();
   parser.addFlag(_helpFlag, abbr: 'h', help: 'Usage help', negatable: false);
   final ArgResults argResults = parser.parse(arguments);

--- a/lib/src/tanslator.dart
+++ b/lib/src/tanslator.dart
@@ -92,7 +92,7 @@ class Translator {
         continue;
       }
 
-      stdout.write('Translating ${preferLang ?? source} to $target...');
+      stdout.writeln('Translating ${preferLang ?? source} to $target...');
 
       // Google Translate requests are limited to 128 strings & 5k characters,
       // so iterate through in chunks if necessary
@@ -137,10 +137,10 @@ class Translator {
         arbFile.writeAsStringSync(encoder.convert(output));
       }
 
-      stdout.write('Translated ${preferLang ?? source} to $target.');
+      stdout.writeln('Translated ${preferLang ?? source} to $target.');
     }
 
-    stdout.write('done.');
+    stdout.writeln('done.');
     exit(0);
   }
 


### PR DESCRIPTION
1. support dynamic templateFilename of type in RegExp: r'^[a-zA-Z0-9]+_[a-zA-Z0-9_\-]+\.arb$'.

template file name can be: intl_en.arb, intl_en_US.arb, app_zh.arb an so on.

Core codes here:
```dart
    final arbDir = _config['arb-dir'] as String? ?? "lib/l10n";
    final templateFilename = _config['template-arb-file'] as String? ?? "app_en.arb";

    final source = templateFilename.substring(templateFilename.indexOf(RegExp(r'[-_]')) + 1, templateFilename.indexOf('.arb'));
    final name = templateFilename.substring(0, templateFilename.indexOf(RegExp(r'[-_]')));
```