### PR TITLE
Add DeepL Translation support to auto_translator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.0
+
+- Added translate-tool configuartion to support for DeepL Translation tool.
+- Fixed bugs that occured when replacing placeholders and parameters.
+
 ## 2.2.0
 
 - Add support for ARB comments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.0
 
-- Added translate-tool configuartion to support for DeepL Translation tool.
+- Added translate-tool configuration to support DeepL Translation tool.
 - Fixed bugs that occured when replacing placeholders and parameters.
 
 ## 2.2.0

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ NOTE: This is the default location. You will see how to specify a different loca
 
 ### (Optional) Setup DeepL Translate
 
-If you do not have DeepL API access, follow DeepL's guide to creating an account and obtaining API access [here] (https://www.deepl.com/pro/change-plan?cta=apiDocsHeader#developer)
+If you do not have DeepL API access, follow DeepL's guide to creating an account and obtaining API access [here](https://www.deepl.com/pro/change-plan?cta=apiDocsHeader#developer)
 
 Save your DeepL API key to a file in your project root called `deepl_key`.
 
@@ -50,7 +50,8 @@ If you have not already created the `l10n.yaml` file, do so now.
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
-### Optional: Set translator-tool if you choose to use a different translate like DeepL. Defaults to Google Translate.
+### Optional: Set translator-tool if you choose to use a different translate like DeepL.
+#Defaults to Google Translate.
 #translate-tool: deepl
 
 translator:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Then save your API key to a file in your project root called `translator_key`.
 
 NOTE: This is the default location. You will see how to specify a different location later in this guide.
 
+### (Optional) Setup DeepL Translate
+
+If you do not have DeepL API access, follow DeepL's guide to creating an account and obtaining API access [here] (https://www.deepl.com/pro/change-plan?cta=apiDocsHeader#developer)
+
+Save your DeepL API key to a file in your project root called `deepl_key`.
+
 ### 2. Add auto_translator to your project
 
 Add auto_translator under dev_dependencies in `pubspec.yaml`
@@ -44,6 +50,8 @@ If you have not already created the `l10n.yaml` file, do so now.
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
+### Optional: Set translator-tool if you choose to use a different translate like DeepL. Defaults to Google Translate.
+#translate-tool: deepl
 
 translator:
   targets:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add auto_translator under dev_dependencies in `pubspec.yaml`
 
 ```yaml
 dev_dependencies:
-  auto_translator: ^2.2.0
+  auto_translator: ^2.3.0
 ```
 
 ### 3. Setup the config files
@@ -50,9 +50,8 @@ If you have not already created the `l10n.yaml` file, do so now.
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
-### Optional: Set translator-tool if you choose to use a different translate like DeepL.
 #Defaults to Google Translate.
-#translate-tool: deepl
+translate-tool: Google
 
 translator:
   targets:

--- a/bin/auto_translator.dart
+++ b/bin/auto_translator.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:auto_translator/src/main.dart';
 
 void main(List<String> arguments) {
-  const version = '2.2.0';
+  const version = '2.3.0';
   stdout.writeln('auto_translator v$version');
   stdout.writeln('═════════════════════');
   runWithArguments(arguments).then((_) => exit(0)).catchError((error) {

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -51,6 +51,22 @@ class GoogleTranslateException extends CustomException {
   const GoogleTranslateException([message]) : super(message);
 }
 
+/// {@template DeepLTranslateException}
+/// Thrown when an error occurs communicating with DeepL Translate.
+/// {@endtemplate}
+class DeepLTranslateException extends CustomException {
+  /// {@macro DeepLTranslateException}
+  const DeepLTranslateException([message]) : super(message);
+}
+
+/// {@template UnsopportedTool}
+/// Thrown when an unsupported translating service is used in the l10n.yaml file.
+/// {@endtemplate}
+class UnsopportedTool extends CustomException {
+  /// {@macro UnsopportedTool}
+  const UnsopportedTool([message]) : super(message);
+}
+
 /// Generic help message linking to package usage guide.
 String get helpMessage =>
     'Please visit https://pub.dev/packages/auto_translator for usage guide.';

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -261,18 +261,15 @@ Future<void> _translate(Map<String, dynamic> config) async {
         source: source,
         target: target,
         translateBackend: config['translateBackend']);
-
+    int matchNum = 0;
     results.updateAll((key, result) {
       var decodedString = transformer.decode(result);
       final exampleMatches = RegExp(r'<.*>').allMatches(decodedString).toList();
-      int match_num = 0;
       for (final match in exampleMatches) {
-        final originalVariable = examples[match_num];
-        if (originalVariable != null) {
-          decodedString = decodedString.replaceRange(
-              match.start, match.end, originalVariable);
-        }
-        match_num += 1;
+        final originalVariable = examples[matchNum];
+        decodedString = decodedString.replaceRange(
+            match.start, match.end, originalVariable);
+        matchNum += 1;
       }
       return decodedString;
     });

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -69,13 +69,18 @@ Map<String, dynamic> _mapConfigEntries(Iterable<MapEntry> entries) {
       config[entry.key] = entry.value;
     }
   }
+  if (!config.containsKey('translate-tool')) {
+    print(
+        "No translate tool was specified in the yaml file, using Google Translate.");
+    config['translate-tool'] = "googleTranslate";
+  }
   final TranslateBackend translateBackend;
   try {
     translateBackend = TranslateBackend.values
         .firstWhere((e) => e.name == config['translate-tool']);
   } catch (e) {
     throw UnsopportedTool(
-        "Please specify a valid translating service in the yaml file");
+        "Please specify a valid translating service in the yaml file.");
   }
   config['translateBackend'] = translateBackend;
   config['key_file'] = translateBackend == TranslateBackend.googleTranslate
@@ -375,7 +380,7 @@ Map<String, dynamic> _buildTemplate(
         (or some custom XML-like tags) should be left untouched.
         */
         // ignore: prefer_interpolation_to_compose_strings
-        String key = '${'<x>' + placeholder.value['example']}<x>';
+        String key = '<x>${placeholder.value['example']}<x>';
         examples.add('{${placeholder.key}}');
         value = value.replaceAll('{${placeholder.key}}', key);
       }

--- a/lib/src/main.dart
+++ b/lib/src/main.dart
@@ -8,6 +8,7 @@ import 'package:auto_translator/src/transformer.dart';
 import 'package:yaml/yaml.dart';
 
 import 'translator.dart';
+import 'translate_backend.dart';
 
 const _helpFlag = 'help';
 const _configOption = 'config-file';
@@ -81,6 +82,11 @@ Future<void> _translate(Map<String, dynamic> config) async {
   final arbDir = config['arb-dir'] as String? ?? "lib/l10n";
   final templateFilename =
       config['template-arb-file'] as String? ?? "app_en.arb";
+  final translateBackendOptions =
+      TranslateBackend.values.where((e) => e.name == config['translate-tool']);
+  final translateBackend = translateBackendOptions.isEmpty
+      ? TranslateBackend.googleTranslate
+      : translateBackendOptions.first;
   final Map<String, dynamic> preferTemplateLang =
       config['prefer-lang-templates']?.cast<String, dynamic>() ?? {};
 
@@ -243,11 +249,14 @@ Future<void> _translate(Map<String, dynamic> config) async {
       );
     });
 
+    stdout.write(
+        'Translating from $source to $target using $translateBackend...');
+
     final results = await translator.translate(
-      toTranslate: toTranslate,
-      source: source,
-      target: target,
-    );
+        toTranslate: toTranslate,
+        source: source,
+        target: target,
+        translateBackend: translateBackend);
 
     results.updateAll((key, result) {
       var decodedString = transformer.decode(result);

--- a/lib/src/translate_backend.dart
+++ b/lib/src/translate_backend.dart
@@ -1,0 +1,1 @@
+enum TranslateBackend { googleTranslate, deepL }

--- a/lib/src/translate_backend.dart
+++ b/lib/src/translate_backend.dart
@@ -1,1 +1,1 @@
-enum TranslateBackend { googleTranslate, deepL }
+enum TranslateBackend { googleTranslate, deepl }

--- a/lib/src/translator.dart
+++ b/lib/src/translator.dart
@@ -56,7 +56,7 @@ class Translator {
             apiKey: _apiKey,
           );
           break;
-        case TranslateBackend.deepL:
+        case TranslateBackend.deepl:
           result = await _deeplTranslate(
             client: _client,
             content: values,

--- a/lib/src/translator.dart
+++ b/lib/src/translator.dart
@@ -131,8 +131,13 @@ class Translator {
         'Content-Type': 'application/json',
         'Accept': 'application/json',
       },
-      body: jsonEncode(
-          {'text': content, 'target_lang': target, 'source_lang': source}),
+      body: jsonEncode({
+        'text': content,
+        'target_lang': target,
+        'source_lang': source,
+        'tag_handling': 'xml',
+        'ignore_tags': ['x']
+      }),
     );
 
     if (response.body.isEmpty) return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.2.0
 homepage: https://github.com/theLee3/flutter_auto_translator
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
   args: ^2.4.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auto_translator
 description: A command-line tool to translate ARB files using Google Cloud Translate.
-version: 2.2.0
+version: 2.3.0
 homepage: https://github.com/theLee3/flutter_auto_translator
 
 environment:


### PR DESCRIPTION
In the new version of the auto_translator I have fixed issues with placeholder replacement for Google Translate and added support for using the translation tool called [DeepL](https://www.deepl.com/translator).

Without any specification of the 'translate-tool' in the l10n.yaml file, the auto_translator defaults back to Google Translate. Thus this new version is backwards compatible; so any program that makes use of auto_translate and does not wish to make use of DeepL functionalities will only benefit from the bug fixes.

All necessary instructions to use DeepL are described on the updated README.md.