### PR TITLE
Add support for multiple translators to be used on a per-target basis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## 2.3.0
 
-- Added translate-tool configuration to support DeepL Translation tool.
-- Fixed bugs that occured when replacing placeholders and parameters.
+- Added support for DeepL Translation.
+- Added `service` configuration option to support different translation services.
+- Added `prefer-service` configuration option to support multiple translator services on a per-language basis.
+- Added `MissingTranslatorKeyException` and `MalformedTranslatorKeyFileException` for key file errors.
+- Fixed bugs that could occur when translating placeholders with examples.
+- Bumped minimum Dart SDK to 3.0.0.
 
 ## 2.2.0
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # Auto Translator
 
-A command-line tool that simplifies translation of an ARB template file to selected languages using Google Cloud Translate. Designed to work seamlessly with the `flutter_localizations` and `intl` packages, Flutter's preferred internationalization approach.
+A command-line tool that simplifies translation of an ARB template file to selected languages. This package is designed to work seamlessly with the `flutter_localizations` and `intl` packages, Flutter's preferred internationalization approach.
 
 ## Features
 
 - Seamless integration with `flutter_localizations` and `intl` packages.
-- Minimal Cloud Translate quota usage.
+- Works with Google Cloud Translate & DeepL Translate.
+- Minimal quota usage.
 - Works with simple & complex ARB strings, conditions, and variables.
 - Uses placeholder examples for more accurate translations involving proper nouns and other unique cases.
+- Specify translator service and/or source language for individual target languages.
 
 ## Support the developer
 
@@ -17,23 +19,27 @@ If you found this package useful, please consider contribuitng to it's continued
 
 ## Getting Started
 
-### 1. Setup Google Cloud Translate
+### 1. Setup Translation Service(s)
+
+Auto Translator supports Google Cloud Translate and DeepL out of the box. You may specify either one as your primary service in the `l10n.yaml` config file. If neither is provided, the default (Google) is used. You may also specify different translators on a per-language basis, as seen in [Preferred Services](#preferred-services).
+
+If you are configuring only one service, you can save the API key in a file in the project root directory called `translator_key` or as a json map in `translator_keys`. If configuring both services, you must use the json map approach.
+
+:warning: **DO NOT** publish your key file to Github or similar VCS.
+
+You can also specify an [alternate key file](#alternate-key-file) path.
+
+#### Google Cloud Translate
 
 If you do not have a Google Cloud Project with the Cloud Translation API enabled, follow the guide [here](https://cloud.google.com/translate/docs/setup).
 
-Then save your API key to a file in your project root called `translator_key`.
-
-NOTE: This is the default location. You will see how to specify a different location later in this guide.
-
-### (Optional) Setup DeepL Translate
+#### DeepL Translate
 
 If you do not have DeepL API access, follow DeepL's guide to creating an account and obtaining API access [here](https://www.deepl.com/pro/change-plan?cta=apiDocsHeader#developer)
 
-Save your DeepL API key to a file in your project root called `deepl_key`.
-
 ### 2. Add auto_translator to your project
 
-Add auto_translator under dev_dependencies in `pubspec.yaml`
+Add `auto_translator` under `dev_dependencies` in `pubspec.yaml`
 
 ```yaml
 dev_dependencies:
@@ -50,10 +56,11 @@ If you have not already created the `l10n.yaml` file, do so now.
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
-#Defaults to Google Translate.
-translate-tool: Google
 
 translator:
+  #Defaults to Google Translate.
+  service: Google
+
   targets:
     - es
     - fr
@@ -62,15 +69,13 @@ translator:
 
 The first three parameters are used by `intl` as well as `auto_translator`. The `translator` section is specific to `auto_translator`.
 
- The `targets` parameter is required and tells `auto_translator` which languages to translate the template file to. Available languages can be found [here](https://cloud.google.com/translate/docs/languages).
+The `targets` parameter is required and tells `auto_translator` which languages to translate the template file to. Available languages can be found [here](https://cloud.google.com/translate/docs/languages).
 
-### Regional Designations
+You can also configure [preferred source templates](#preferred-templates) for any given target language.
 
- You can use 2-letter language codes or include regional designations (en-US, en-GB, es-Es, etc.).
+#### Regional Designations
 
-An optional `key_file` parameter can be provided if you wish to store your Google Translate API key somehwere other than the default location.
-
-:warning: **DO NOT** publish your key file to Github or similar VCS.
+You can use 2-letter language codes and regional designations (en-US, en-GB, es-Es, etc.).
 
 ### 4. Run the package
 
@@ -131,18 +136,51 @@ You can also tell the translator to ignore a particular message with the `ignore
 
 ### Preferred Templates
 
-Sometimes, you may wish to specify a language that translates more accurately to a target than the language used in the `template-arb-file`. For that, you can now provide a `prefer-lang-templates` map to specify a preferred language to use as a template for any target language.
+Sometimes, you may wish to specify a language that translates more accurately to a target than the language used in the `template-arb-file`. For that, you can provide a `prefer-lang-templates` map to specify a preferred source language to use as a template for any target language.
 
 ```yaml
 translator:
   # use es template for fr translation ja for ko
   # all other translations will use [template-arb-file]
-  prefer-lang-templates: {
-    'fr': 'es',
-    'ko': 'ja',
-  }
+  prefer-lang-templates:
+    fr: es
+    ko: ja
+```
+
+### Preferred Services
+
+As one service may outperform the other in a given language you may wish to specify a service an a per-language basis. This can be done by providing a `prefer-service` map in the config file.
+
+```yaml
+translator:
+  # use DeepL for tr and uk
+  # all other translations will use the primary service
+  # (presumably Google in this case)
+  prefer-service:
+    # capitilization does not matter for service name
+    DeepL:
+      - tr
+      - uk
+```
+
+Each API key must be provided in the key file (service name capitalization does not matter).
+
+```json
+{
+  "google": "CLOUD_TRANSLATE_API_KEY",
+  "deepL": "DEEP_L_API_KEY"
+}
 ```
 
 ### Alternate config file
 
 By default, the config file is named `l10n.yaml` and is located in the project's root directory. You can pass in an alternate file path when running on the command line using the `--config-file` option.
+
+### Alternate key file
+
+By default, `auto_translator` looks for keys in the project root at `translator_keys` or `translator_key`. You may specify a different location in the config file.
+
+```yaml
+translator:
+  key_file: path/to/key/file
+```

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -19,6 +19,7 @@ linter:
   rules:
     - public_member_api_docs
 #     - camel_case_types
+    - prefer_single_quotes
 
 # analyzer:
 #   exclude:

--- a/example/l10n.yaml
+++ b/example/l10n.yaml
@@ -4,6 +4,7 @@ output-localization-file: app_localizations.dart
 
 translator:
   # key_file: translator_key
+  # service: Google
   targets:
     - es-ES
     - de
@@ -12,7 +13,15 @@ translator:
     - tr
     - uk
 
-  prefer-lang-templates: {
-    'fr': 'es-ES',
-    'uk': 'de'
-  }
+  prefer-lang-templates: 
+    fr: es-ES
+    de: es-ES
+    uk: de
+  
+  prefer-service:
+    deepL:
+      - tr
+      - uk
+    # Google:
+    #   - es-Es
+  

--- a/lib/src/exceptions.dart
+++ b/lib/src/exceptions.dart
@@ -43,6 +43,27 @@ class InvalidFormatException extends CustomException {
             'opening or closing curly brace in `$key`.');
 }
 
+/// {@template MissingTranslatorKeyException}
+/// Thrown when a key has not been provided for a specified translator.
+/// {@endtemplate}
+class MissingTranslatorKeyException extends CustomException {
+  /// {@MissingTranslatorKeyException}
+  const MissingTranslatorKeyException([message]) : super(message);
+}
+
+/// {@template MalformedTranslatorKeyFileException}
+/// Thrown when the key file is not formatted correctly.
+/// {@endtemplate}
+class MalformedTranslatorKeyFileException extends CustomException {
+  /// {@MalformedTranslatorKeyFileException}
+  const MalformedTranslatorKeyFileException()
+      : super(
+          'The key file must consists of a single string or a json map. See '
+          'https://pub.dev/packages/auto_translator#3-setup-the-config-files '
+          'for more details.',
+        );
+}
+
 /// {@template GoogleTranslateException}
 /// Thrown when an error occurs communicating with Google Cloud Translate.
 /// {@endtemplate}
@@ -59,12 +80,12 @@ class DeepLTranslateException extends CustomException {
   const DeepLTranslateException([message]) : super(message);
 }
 
-/// {@template UnsopportedTool}
-/// Thrown when an unsupported translating service is used in the l10n.yaml file.
+/// {@template UnsupportedTranslatorServiceException}
+/// Thrown when an unsupported translator service is specified in the l10n.yaml file.
 /// {@endtemplate}
-class UnsopportedTool extends CustomException {
-  /// {@macro UnsopportedTool}
-  const UnsopportedTool([message]) : super(message);
+class UnsupportedTranslatorServiceException extends CustomException {
+  /// {@macro UnsupportedTranslatorServiceException}
+  const UnsupportedTranslatorServiceException([message]) : super(message);
 }
 
 /// Generic help message linking to package usage guide.

--- a/lib/src/transformer.dart
+++ b/lib/src/transformer.dart
@@ -6,7 +6,7 @@ import 'exceptions.dart';
 class Transformer {
   final _openBracket = RegExp(r"(?<!'){");
   final _closeBracket = RegExp(r"(?<!')}");
-  final _commaAndAnyTrailingWhitespace = RegExp(r",\s*");
+  final _commaAndAnyTrailingWhitespace = RegExp(r',\s*');
 
   // expression used to for arb variables
   final _variableExp = RegExp(r'\[_\d*\]');

--- a/lib/src/translate_backend.dart
+++ b/lib/src/translate_backend.dart
@@ -1,1 +1,0 @@
-enum TranslateBackend { googleTranslate, deepl }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.3.0
 homepage: https://github.com/theLee3/flutter_auto_translator
 
 environment:
-  sdk: '>=2.15.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   args: ^2.4.2

--- a/test/test.dart
+++ b/test/test.dart
@@ -7,26 +7,25 @@ import 'package:path/path.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('exceptions', () {
-    final testDir = join('.dart_tool', 'arb_translator', 'test');
+  final testDir = join('.dart_tool', 'arb_translator', 'test');
 
-    late String currentDirectory;
-    void setCurrentDirectory(String path) {
-      path = join(testDir, path);
-      Directory(path).createSync(recursive: true);
-      Directory.current = path;
-    }
+  late String currentDirectory;
+  void setCurrentDirectory(String path) {
+    path = join(testDir, path);
+    Directory(path).createSync(recursive: true);
+    Directory.current = path;
+  }
 
-    setUp(() {
-      currentDirectory = Directory.current.path;
-      setCurrentDirectory('default');
-    });
+  setUp(() {
+    currentDirectory = Directory.current.path;
+    setCurrentDirectory('default');
+  });
 
-    tearDown(() {
-      Directory.current.parent.parent.deleteSync(recursive: true);
-      Directory.current = currentDirectory;
-    });
-
+  tearDown(() {
+    Directory.current.parent.parent.deleteSync(recursive: true);
+    Directory.current = currentDirectory;
+  });
+  group('config:', () {
     // Test ConfigNotFoundException
     test('missing config file', () async {
       await expectLater(() async => await runWithArguments([]),
@@ -56,9 +55,28 @@ translator:
       await expectLater(() async => await runWithArguments([]),
           throwsA(isA<NoTargetsProvidedException>()));
     });
+  });
 
-    // Test missing key file. A key file is required to use the Google Translation API
+  group('keys:', () {
+    // Test missing key file. A key file is required to use the APIs
     test('missing key file', () async {
+      File('l10n.yaml').writeAsStringSync('''
+arb-dir: lib/l10n
+template-arb-file: app_en-US.arb
+output-localization-file: app_localizations.dart
+
+translator:
+  key_file: path/to/key/file
+  targets:
+    - es-ES
+''');
+
+      await expectLater(() async => await runWithArguments([]),
+          throwsA(isA<MissingTranslatorKeyException>()));
+    });
+
+    // Test MalformedTranslatorKeyFileException
+    test('invalid key file format', () async {
       File('l10n.yaml').writeAsStringSync('''
 arb-dir: lib/l10n
 template-arb-file: app_en-US.arb
@@ -69,10 +87,33 @@ translator:
     - es-ES
 ''');
 
+      File('translator_keys').writeAsStringSync('{s0meArb1tr4ryK3yV4lu3:}');
+
       await expectLater(() async => await runWithArguments([]),
-          throwsA(isA<GoogleTranslateException>()));
+          throwsA(isA<MalformedTranslatorKeyFileException>()));
     });
 
+    // Test MissingTranslatorKeyException
+    test('missing key in key file', () async {
+      File('l10n.yaml').writeAsStringSync('''
+arb-dir: lib/l10n
+template-arb-file: app_en-US.arb
+output-localization-file: app_localizations.dart
+
+translator:
+  targets:
+    - es-ES
+''');
+
+      File('translator_keys')
+          .writeAsStringSync('{"deepL": "s0meArb1tr4ryK3yV4lu3"}');
+
+      await expectLater(() async => await runWithArguments([]),
+          throwsA(isA<MissingTranslatorKeyException>()));
+    });
+  });
+
+  group('arb:', () {
     // Test InvalidFormatException
     test('invalid format', () async {
       File('l10n.yaml').writeAsStringSync('''
@@ -81,6 +122,7 @@ template-arb-file: app_en-US.arb
 output-localization-file: app_localizations.dart
 
 translator:
+  key_file: translator_key
   targets:
     - es-ES
 ''');
@@ -97,17 +139,15 @@ translator:
       await expectLater(() async => await runWithArguments([]),
           throwsA(isA<InvalidFormatException>()));
     });
-  });
 
-  group('transform', () {
     test('transform', () {
       // Create the template file containing 4 values of varying complexity
       final arbTemplate = {
-        "appTitle": "Demo App",
-        "greeting": "Hello, {world}!",
-        "birthday":
-            "{sex, select, male{His birthday} female{Her birthday} other{Their birthday}}",
-        "complexExample":
+        'appTitle': 'Demo App',
+        'greeting': 'Hello, {world}!',
+        'birthday':
+            '{sex, select, male{His birthday} female{Her birthday} other{Their birthday}}',
+        'complexExample':
             "{mode, select, 0{Test with {variable_name_type1}} 1{Test with {variableNameType2}} 2{{oneMore_for_goodMeasure} at the start this time.} other{Test using the '{select placeholder'} as well: {mode}}}",
       };
 


### PR DESCRIPTION
We can use Google Cloud Translate or DeepL Translate on for the entire project or configure which service is used by specific target languages.